### PR TITLE
Slight tweak so it reads the array

### DIFF
--- a/includes/objects/post.php
+++ b/includes/objects/post.php
@@ -1113,9 +1113,11 @@ class titania_post extends \phpbb\titania\entity\message_base
 				break;
 		}
 
-		if (isset(titania::$config->$type[$mode]))
+		$forums = titania::$config->$type;
+
+		if (isset($forums[$mode]))
 		{
-			return (int) titania::$config->$type[$mode];
+			return (int) $forums[$mode];
 		}
 
 		return 0;


### PR DESCRIPTION
I just brought `titania::$config->$type` out into its own variable before calling the array key. It just wasn't reading the array for me the way it was. Maybe it's a PHP version related issue.